### PR TITLE
fix: don't apply populated data until getPresentableObject

### DIFF
--- a/src/mongoose/plugins/getPresentableObject.ts
+++ b/src/mongoose/plugins/getPresentableObject.ts
@@ -19,11 +19,11 @@ const getPresentableObject = (schema: Schema): void => {
 
     schema.methods.getPresentableObject = function (): Record<string, unknown> {
         const document = this as Document;
-        const populatedDocument = document["$populated"] as Document;
+        const populatedData = document["$populated"];
 
-        const selectedDocument = populatedDocument || document;
+        const selectedDocument = populatedData || document;
 
-        const rawDocument = document["$raw"];
+        const rawDocumentData = document["$raw"];
 
         const newObject: Record<string, unknown> = {
             id: selectedDocument.id
@@ -42,7 +42,7 @@ const getPresentableObject = (schema: Schema): void => {
                 continue;
             }
 
-            const newValue = selectedDocument[field] || rawDocument[field];
+            const newValue = selectedDocument[field] || rawDocumentData[field];
 
             newObject[field] = newValue;
         }

--- a/src/mongoose/plugins/getPresentableObject.ts
+++ b/src/mongoose/plugins/getPresentableObject.ts
@@ -98,7 +98,9 @@ const getPresentableObject = (schema: Schema): void => {
 
             doc["$raw"] = doc.toObject();
 
-            for (const field of presentableFields) {
+            const nonPopulated = presentableFields.filter((field) => !doc.populated(field));
+
+            for (const field of nonPopulated) {
                 doc.populate(field);
             }
 
@@ -106,7 +108,7 @@ const getPresentableObject = (schema: Schema): void => {
 
             doc["$populated"] = doc.toJSON();
 
-            for (const field of presentableFields) {
+            for (const field of nonPopulated) {
                 doc.depopulate(field);
             }
         }

--- a/src/mongoose/plugins/getPresentableObject.ts
+++ b/src/mongoose/plugins/getPresentableObject.ts
@@ -19,9 +19,14 @@ const getPresentableObject = (schema: Schema): void => {
 
     schema.methods.getPresentableObject = function (): Record<string, unknown> {
         const document = this as Document;
+        const populatedDocument = document["$populated"] as Document;
+
+        const selectedDocument = populatedDocument || document;
+
+        const rawDocument = document["$raw"];
 
         const newObject: Record<string, unknown> = {
-            id: document.id
+            id: selectedDocument.id
         };
 
         const modifiedPresentableFields = { ...presentableFields };
@@ -37,7 +42,9 @@ const getPresentableObject = (schema: Schema): void => {
                 continue;
             }
 
-            newObject[field] = document[field];
+            const newValue = selectedDocument[field] || rawDocument[field];
+
+            newObject[field] = newValue;
         }
 
         // These properties are *always* hidden, regardless of configuration, since they are never of any use to the client
@@ -87,11 +94,21 @@ const getPresentableObject = (schema: Schema): void => {
         for (const doc of docs) {
             if (!(doc instanceof Document)) continue;
 
-            for (const field of doc.getPopulateableFields()) {
+            const presentableFields = doc.getPopulateableFields();
+
+            doc["$raw"] = doc.toObject();
+
+            for (const field of presentableFields) {
                 doc.populate(field);
             }
 
             await doc.execPopulate();
+
+            doc["$populated"] = doc.toJSON();
+
+            for (const field of presentableFields) {
+                doc.depopulate(field);
+            }
         }
 
         return next();

--- a/typings/mongoose.d.ts
+++ b/typings/mongoose.d.ts
@@ -12,6 +12,10 @@ declare module "mongoose" {
     export type PresentableField<T = null> = PartialRecord<PresentableFieldKey<T>, PresentableFieldValue>;
 
     interface Document {
+        "$raw": Record<string, unknown>;
+        "$populated": Record<string, unknown>;
+        "$presentables": PresentableField;
+
         /**
          * Returns the presentable object, populated and cleaned up, ready to be sent to the client
          */


### PR DESCRIPTION
This resolves a lot of bugs, where we rely on populate-able fields to be the document ID's, not their populated counterpart. Example being: https://github.com/harmonyapp/api/blob/e6e2b7409c6ec7159fe1bf1d2849754ec365cae9/src/api/v1/controllers/servers/server/ServerController.ts#L72-L74

This would always be false, since the left-hand side of the comparison would always be the user object, while the right-hand side would always be the ID as a string