### PR TITLE
refactor: define function shape instead of using Function type

### DIFF
--- a/src/mongoose/plugins/getPresentableObject.ts
+++ b/src/mongoose/plugins/getPresentableObject.ts
@@ -43,7 +43,7 @@ const getPresentableObject = (schema: Schema): void => {
             }
 
             if (typeof presentableFieldValue === "function") {
-                const shouldPresent = (presentableFieldValue as Function).call(document);
+                const shouldPresent = (presentableFieldValue as () => boolean).call(document);
 
                 if (!shouldPresent) {
                     continue;


### PR DESCRIPTION
Accidentally pushed to master while under the impression that it would fail, and it instantly backfired by failing tests