### PR TITLE
perf(getPresentableObject): move query population to pre find hook

### DIFF
--- a/src/api/v1/controllers/servers/server/channels/ServerChannelsController.ts
+++ b/src/api/v1/controllers/servers/server/channels/ServerChannelsController.ts
@@ -45,9 +45,7 @@ class ServerChannelsController extends BaseController {
             return next(error);
         }
 
-        const siblings = await channel.getSiblings();
-
-        channel.position = siblings.length;
+        channel.position = await channel.countSiblings();
 
         try {
             await channel.save();

--- a/src/models/server.ts
+++ b/src/models/server.ts
@@ -42,7 +42,7 @@ export interface IServerDocument extends Document {
     mendChannelPositions({ channel_type, save }: {
         channel_type: "category" | "channel",
         save?: boolean
-    }): Promise<[IChannelDocument[]]>;
+    }): Promise<IChannelDocument[]>;
 }
 
 const serverSchema = new Schema({
@@ -72,7 +72,7 @@ serverSchema.methods.mendChannelPositions = async function ({
 }) {
     const document = this as IServerDocument;
 
-    const serverChannels = await Channel.find({ server: document.id });
+    const serverChannels = await Channel.find({ server: document.id }).raw();
 
     const channels = serverChannels.filter((channel) => {
         if (channel_type === "category") {

--- a/typings/mongoose.d.ts
+++ b/typings/mongoose.d.ts
@@ -4,11 +4,11 @@ declare module "mongoose" {
     }
 
     export type PresentableFieldKey<T = any> = (keyof { [P in keyof Omit<T, keyof Document>] } | (string & {}));
-    export type PresentableFieldValue<T = Document> = boolean | {
+    export type PresentableFieldValue = boolean | {
         populate: boolean;
-    } | ((this: T) => boolean | { populate: boolean });
+    };
 
-    export type PresentableField<T = null> = PartialRecord<PresentableFieldKey<T>, PresentableFieldValue<T>>;
+    export type PresentableField<T = null> = PartialRecord<PresentableFieldKey<T>, PresentableFieldValue>;
 
     interface Document {
         "$raw": Record<string, unknown>;
@@ -20,14 +20,10 @@ declare module "mongoose" {
          */
         getPresentableObject(): Record<string, unknown>;
         /**
-         * Returns all fields that are subject to being populated, if any
-         */
-        getPopulateableFields(): string[];
-        /**
          * Configure a single presentable field.
          * <note>This applies only to the single document it's run on</note>
          */
-        setPresentableField(key: PresentableFieldKey<this> | string, value: PresentableFieldValue<this>): Document;
+        setPresentableField(key: PresentableFieldKey<this> | string, value: PresentableFieldValue): Document;
         /**
          * Configure the presentable fields for the document.
          * <note>This only overwrites the fields that were provided, the others remain intact.</note>
@@ -45,5 +41,9 @@ declare module "mongoose" {
          * Configure the presentable fields for this model
          */
         setPresentableFields(fields: PresentableField<T>): void;
+    }
+
+    interface DocumentQuery<T, DocType extends Document, QueryHelpers = {}> {
+        raw<T extends Document>(): DocumentQuery<DocType[], DocType, QueryHelpers> & QueryHelpers;
     }
 }


### PR DESCRIPTION
This heavily reduces the amount of database queries required to populate the fields. The original method, when fetching i.e. a channel, would result in about 3 database queries *per channel*. If we fetched about 100 channels at the same time, which is not uncommon, we would have to perform about 300 queries just for population. This peformance update will reduce it to around 3 extra queries *in total*.