### PR TITLE
feat: create new plugin to set wasNew flag in post-save hook in mongoose

### DIFF
--- a/src/mongoose/db.ts
+++ b/src/mongoose/db.ts
@@ -1,8 +1,10 @@
 import mongoose from "mongoose";
 import { MongoMemoryServer } from "mongodb-memory-server";
 import getPresentableObject from "./plugins/getPresentableObject";
+import wasNew from "./plugins/wasNew";
 
 mongoose.plugin(getPresentableObject);
+mongoose.plugin(wasNew);
 
 const staging = process.env.NODE_ENV === "test";
 

--- a/src/mongoose/plugins/wasNew.ts
+++ b/src/mongoose/plugins/wasNew.ts
@@ -1,0 +1,14 @@
+import { Schema } from "mongoose";
+
+// In a post-save hook, Document#isNew is always false, even if the document is new.
+// This plugin adds a new property called wasNew, which will reflect whether the document actually is new or not in the post-hook
+
+const wasNew = (schema: Schema): void => {
+    schema.pre("save", function (next) {
+        this.wasNew = this.isNew;
+
+        next();
+    });
+};
+
+export default wasNew;

--- a/typings/mongoose.d.ts
+++ b/typings/mongoose.d.ts
@@ -15,6 +15,8 @@ declare module "mongoose" {
         "$populated": Record<string, unknown>;
         "$presentables": PresentableField;
 
+        wasNew: boolean;
+
         /**
          * Returns the presentable object, populated and cleaned up, ready to be sent to the client
          */


### PR DESCRIPTION
In the post-save hook in mongoose, the isNew flag is always false, regardless of whether the document is new or not. This plugin creates a wasNew flag that reflects the state of the isNew flag when it was in the pre-save hook, so we can use it post-save.