### PR TITLE
fix(Server): create default channels in post-save hook

### DIFF
--- a/src/models/server.ts
+++ b/src/models/server.ts
@@ -134,18 +134,18 @@ serverSchema.pre<IServerDocument>("validate", function (next) {
     next();
 });
 
-serverSchema.pre<IServerDocument>("save", async function (next) {
-    if (this.isNew) {
+serverSchema.post<IServerDocument>("save", async function (doc, next) {
+    if (doc.wasNew) {
         const defaultCategory = new Channel({
             name: "General",
-            server: this.id,
+            server: doc.id,
             type: ChannelTypes.SERVER_CATEGORY,
             position: 0
         });
 
         const defaultChannel = new Channel({
             name: "general",
-            server: this.id,
+            server: doc.id,
             type: ChannelTypes.SERVER_TEXT,
             position: 0,
             parent: defaultCategory.id


### PR DESCRIPTION
When this functionality was in the pre-save hook, the getPresentableObject plugin would try to populate the server of the channel, but since the server hadn't actually been saved to the database yet, the server field would be null. Now, since it's in the post-save hook, the server will actually exist, and the field will be populated as it should